### PR TITLE
rescue: replace prescriptive system prompt with minimal sub-invocation hint

### DIFF
--- a/runtime/agents/rescue.yaml
+++ b/runtime/agents/rescue.yaml
@@ -2,7 +2,6 @@ version: 1
 agent:
   extend: default
   name: kimi-plugin-rescue
-  system_prompt_path: ../prompts/rescue-system.md
   exclude_tools:
     - "kimi_cli.tools.agent:Agent"
     - "kimi_cli.tools.ask:AskUserQuestion"

--- a/runtime/prompts/rescue-system.md
+++ b/runtime/prompts/rescue-system.md
@@ -1,7 +1,5 @@
-Work as a delegated rescue operator inside the current repository.
+You are a delegated sub-invocation running inside the kimi-plugin-cc rescue profile. Commit to an interpretation of the task without asking clarifying questions; your output will be read by Claude and relayed to the user.
 
-- You may inspect files, edit files, and run bounded local shell checks that the companion approves.
-- Keep work focused on the user’s stated repair, debugging, or implementation task.
-- Do not use web tools, nested agents, or background-task tools.
-- Return exactly one JSON object matching the rescue output schema with no prose wrapper and no code fences.
-- If the task is blocked or only partially complete, say so explicitly in the JSON `status`, `summary`, `tests`, and `followups` fields.
+Begin your response with a one-line summary of the outcome or finding, then elaborate in prose.
+
+Use single-command shell invocations. The companion's approval allowlist rejects `&&`, `||`, pipes, subshells, and backticks — compound shell syntax will fail the rescue.


### PR DESCRIPTION
## Summary

- Replace `runtime/prompts/rescue-system.md` with a 3-paragraph minimal hint: (1) non-interactive interpretation commitment, (2) one-line summary lead for `firstMeaningfulLine` summary derivation, (3) single-command shell guidance because the approval allowlist rejects `&&`, `||`, pipes, subshells, and backticks.
- Remove `system_prompt_path: ../prompts/rescue-system.md` from `runtime/agents/rescue.yaml`; `extend: default` alone handles prompt inheritance.
- Drop the 7-line cargo-cult prescription that forced JSON output, duplicated tool exclusions already enforced by `exclude_tools`, and imposed output schemas.

Empirical verification during the research phase (5 real rescue runs with the prompt stripped) confirmed Kimi's default `--wire` behavior is mostly clean and only needs those three nudges. This is Stream B Unit 1 of the 0.1.7 refactor running in parallel with Stream A's main pass-through render path rewrite.

## Test plan

- [x] `bun run check` — 107 passed, 1 skipped (live Kimi integration), dist drift gate clean (no `runtime/**/*.ts` changed so no rebuild needed)
- [x] `wc -l runtime/prompts/rescue-system.md` → 5 lines (3 paragraphs + 2 blank separators)
- [x] `grep -c system_prompt_path runtime/agents/rescue.yaml` → 0
- [ ] End-to-end rescue validation deferred to Stream A (requires the pass-through render path so rescue output isn't masked)