### PR TITLE
scripts: add operator-run rescue drift detection smoke

### DIFF
--- a/scripts/smoke-rescue-drift.sh
+++ b/scripts/smoke-rescue-drift.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# scripts/smoke-rescue-drift.sh — manual drift detection for rescue under minimal prompt.
+#
+# Purpose: catch behavioral regressions in Kimi's --wire default agent behavior that
+# would break pass-through rescue (introduced in 0.1.7). Run manually after:
+#   - upgrading Kimi CLI
+#   - changing runtime/prompts/rescue-system.md
+#   - suspected upstream drift
+#
+# This script is NOT wired into `bun run check` because real CI does not have Kimi
+# installed or authenticated. It is operator-invoked only.
+#
+# Exit codes: 0 = pass, 1 = fail with diagnostic on stderr.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+PROMPT="In one sentence, describe what this repository is for based on README.md. Do not edit any files."
+
+echo "Running rescue drift check..." >&2
+OUTPUT=$(./scripts/companion.sh task rescue "$PROMPT" 2>&1)
+
+# 1. Rescue must complete cleanly (not partial, not failed, not approval-rejected).
+if ! echo "$OUTPUT" | grep -q "Status: completed"; then
+  echo "FAIL: rescue did not report Status: completed" >&2
+  echo "$OUTPUT" >&2
+  exit 1
+fi
+
+# 2. No approval rejection — indicates Kimi tried compound shell syntax (&&, pipes, etc.)
+#    that the allowlist blocks. This is the run-5 failure mode from the 0.1.7 verification.
+if echo "$OUTPUT" | grep -q "APPROVAL_REJECTED"; then
+  echo "FAIL: approval allowlist rejected Kimi's tool usage — possible drift in default shell style" >&2
+  echo "$OUTPUT" >&2
+  exit 1
+fi
+
+# 3. Extract the raw final output block and verify it is substantive.
+RAW=$(echo "$OUTPUT" | sed -n '/^## Raw Final Output/,/^```$/p' | sed '1,2d;$d')
+if [ -z "$RAW" ]; then
+  echo "FAIL: empty raw final output" >&2
+  echo "$OUTPUT" >&2
+  exit 1
+fi
+
+RAW_LEN=${#RAW}
+if [ "$RAW_LEN" -lt 40 ]; then
+  echo "FAIL: raw final output suspiciously short ($RAW_LEN chars): $RAW" >&2
+  exit 1
+fi
+
+# 4. First meaningful line must not look like a clarifying question.
+FIRST=$(echo "$RAW" | awk 'NF {print; exit}')
+if echo "$FIRST" | grep -qiE '(could you clarify|which do you mean|what exactly|\?$)'; then
+  echo "FAIL: rescue asked a clarifying question — drift in non-interactive commit behavior" >&2
+  echo "First line: $FIRST" >&2
+  exit 1
+fi
+
+echo "PASS: rescue drift check clean." >&2
+echo "First line: $FIRST" >&2
+exit 0


### PR DESCRIPTION
## Summary
- Adds `scripts/smoke-rescue-drift.sh`, a manual operator-run smoke test that catches behavioral regressions in Kimi's `--wire` default agent behavior that would break pass-through rescue (introduced in 0.1.7).
- Not wired into `bun run check` — real CI has no authenticated Kimi. Invoke manually after upgrading Kimi CLI, editing `runtime/prompts/rescue-system.md`, or when debugging suspected upstream drift.
- Mirrors `scripts/companion.sh` style: `set -euo pipefail`, explicit `cd`, diagnostics to stderr.

Assertions, in order:
1. Rescue reports `Status: completed` (not `partial`/`failed`).
2. No `APPROVAL_REJECTED` — that would indicate Kimi drifted into compound shell syntax the allowlist blocks (run-5 failure mode from 0.1.7 verification).
3. Raw final output block is non-empty and at least 40 chars.
4. First meaningful line is not a clarifying question (drift in non-interactive commit behavior).

## Test plan
- [x] `bash -n scripts/smoke-rescue-drift.sh` — syntax valid
- [x] `[ -x scripts/smoke-rescue-drift.sh ]` — executable bit set
- [x] `bun run check` — 107 pass, 1 skip, 0 fail (standalone bash, not exercised by any test)
- [ ] Do **not** execute the script yet: the 0.1.7 pass-through refactor is still in flight on Stream A, so `Status: completed` would fail against the current `partial` rescue output. This script is explicitly a post-0.1.7 operator tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)