### PR TITLE
docs: remove rescue-JSON references from runtime READMEs

### DIFF
--- a/runtime/README.md
+++ b/runtime/README.md
@@ -7,7 +7,7 @@ Command surface exposed via `companion.ts`:
 - `setup` — verify `kimi --wire` round-trip and manage review-gate config
 - `review` / `task challenge` — read-only reviews with fixed JSON schemas
 - `ask` — read-only free-form Q&A (fresh session per call)
-- `task rescue` — write-capable rescue with a companion-side approval allowlist and resumable Kimi sessions
+- `task rescue` — write-capable delegated task channel with a companion-side approval allowlist and resumable Kimi sessions; output is pass-through prose (no schema)
 - `status` / `result` / `cancel` — SQLite-backed job lifecycle commands
 - `replay <job-id>` — re-render a stored Wire event log through the same buffer-after-last-ToolResult path the live runtime uses
 
@@ -32,7 +32,7 @@ Behavior notes:
 - `start()`, `initialize()`, and (for ask/review) `prompt()` are wrapped in `withTimeout` so a Kimi that starts but never becomes usable surfaces a clean timeout instead of hanging forever
 - Rescue session resume is guarded by a partial unique index; two concurrent `/kimi:rescue --resume` calls against the same session id cannot both enter the running state
 - The Stop hook is disabled by default and reads `reviewGateEnabled` from plugin config; enable via `/kimi:setup --enable-review-gate`
-- Parse failure is a hard failure for `review`/`challenge`, a `completed` job with `error` set for `rescue` (raw output preserved), and a warn-allow for `review_gate`
+- Parse failure is a hard failure for `review`/`challenge` and a warn-allow for `review_gate`; `rescue` has no schema to parse against — Kimi's raw final output is stored verbatim and rendered as-is
 - Raw Wire traffic is logged to `${CLAUDE_PLUGIN_DATA}/kimi-plugin-cc/logs/<command>-<job-id>.jsonl` for replay and debugging
 - The companion runs on Node via `tsx` (ADR 003) while Bun stays the package manager and test runner
 
@@ -40,7 +40,7 @@ Subdirectories:
 
 - `agents/` — Kimi agent profiles (read-only: review, ask, review-gate; write-capable: rescue)
 - `prompts/` — system prompts per command type
-- `schemas/` — structured output contracts (review, rescue, review-gate)
+- `schemas/` — structured output contracts (review, review-gate); rescue is pass-through prose and has no schema
 - `hooks/` — Stop hook entry point for the review gate
 - `commands/` — one file per companion subcommand
 - `wire/` — Wire client + turn capture

--- a/runtime/prompts/README.md
+++ b/runtime/prompts/README.md
@@ -1,10 +1,8 @@
 # runtime/prompts
 
-Placeholder directory for prompt templates used by the local runtime.
+System prompts used by the local runtime.
 
-Planned prompt families:
-
-- review
-- challenge
-- rescue
-- review gate
+- `review-system.md` — review/challenge structured-output prompt
+- `ask-system.md` — read-only free-form Q&A prompt
+- `rescue-system.md` — delegated task channel; intentionally minimal (a few lines) because rescue output is pass-through prose with no schema to enforce
+- `review-gate-system.md` — Stop-hook allow/block prompt

--- a/runtime/schemas/README.md
+++ b/runtime/schemas/README.md
@@ -1,9 +1,8 @@
 # runtime/schemas
 
-Placeholder directory for structured output schemas.
+Structured output contracts for commands whose output is schema-validated.
 
-Planned schemas:
+- `review-output.ts` — review / challenge finding schema (one-file-per-finding)
+- `review-gate-output.ts` — Stop-hook allow/block decision schema
 
-- review output
-- rescue output
-- review gate allow/block output
+Rescue is deliberately absent. As of 0.1.7, rescue output is pass-through prose: Kimi's raw final output is stored verbatim and rendered as-is, with no schema, no parser, and no renderer transformation. The plugin still owns transport, session, workspace, tool scope, approval policy, and job lifecycle; Kimi owns content, reasoning, and prose.


### PR DESCRIPTION
## Summary

Targeted README edits in support of the 0.1.7 rescue pass-through refactor. Rescue output is now pass-through prose — Kimi's raw final output is stored verbatim and rendered as-is, with no schema, parser, or renderer transform. This unit cleans up the three runtime documentation READMEs so they no longer describe rescue as having a structured JSON output contract.

- `runtime/README.md`: describe rescue as a write-capable delegated task channel; drop the rescue-specific "completed with error set / raw preserved" parse policy and the "schemas/ contains rescue" bullet.
- `runtime/prompts/README.md`: replace the placeholder list with the actual prompt files; note `rescue-system.md` is intentionally minimal because rescue has no schema to enforce.
- `runtime/schemas/README.md`: list the remaining review and review-gate schemas; call out rescue's deliberate absence and restate the 0.1.7 ownership split (plugin owns transport / session / workspace / tool scope / approval / lifecycle; Kimi owns content / reasoning / prose).

Preserved unchanged: rescue approval allowlist and tool scoping, the rescue agent profile's `exclude_tools` list, rescue being the only write-capable profile, review / challenge / review-gate schema sections, ask as a read-only prose command, and the setup / status / result / cancel / replay command surface.

Scope was deliberately narrow — targeted edits only, no wholesale rewrite. Three parallel side-quest units are coordinating the 0.1.7 refactor; this is the docs unit.

## Test plan

- [x] `bun run check` — 107 pass, 1 skip, 0 fail; tsc and dist drift gate clean
- [x] `grep -iE '(parseRescueOutput|renderRescueArtifact|rescue.*schema|rescue.*json)'` across the three READMEs returns only the new phrasing that explicitly states rescue has no schema
- [x] Visual scan: no orphaned headings or dangling cross-references
- [ ] E2E skipped per coordinator instructions (prose-only change, no code path affected, `bun test` does not validate markdown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)