### PR TITLE
kimi-web-client: normalize URLs and add AbortController timeout tests

### DIFF
--- a/dist/kimi-web-client.js
+++ b/dist/kimi-web-client.js
@@ -23,6 +23,15 @@ export function resolveKimiWebBaseUrl(env) {
         return DEFAULT_KIMI_WEB_BASE_URL;
     return override.replace(/\/+$/, "");
 }
+// Join a base URL (e.g. `http://127.0.0.1:5494` or `http://127.0.0.1:5494/`)
+// with an absolute path (e.g. `/healthz`) without producing a double slash.
+// Uses the WHATWG URL parser so the result is always canonical. Note:
+// `new URL("/x", "http://host/sub/")` drops `/sub/`, which is correct here
+// because `baseUrl` is always an origin-only URL as produced by
+// `resolveKimiWebBaseUrl` — never a URL with a path suffix.
+function joinUrl(baseUrl, path) {
+    return new URL(path, baseUrl).toString();
+}
 export function createKimiWebClient(options = {}) {
     const baseUrl = resolveKimiWebBaseUrl(options.env);
     const fetchImpl = options.fetchImpl ?? fetch;
@@ -32,7 +41,7 @@ export function createKimiWebClient(options = {}) {
             const controller = new AbortController();
             const timer = setTimeout(() => controller.abort(), KIMI_WEB_HEALTH_TIMEOUT_MS);
             try {
-                const response = await fetchImpl(`${baseUrl}${KIMI_WEB_HEALTH_PATH}`, {
+                const response = await fetchImpl(joinUrl(baseUrl, KIMI_WEB_HEALTH_PATH), {
                     method: "GET",
                     signal: controller.signal,
                 });
@@ -60,7 +69,7 @@ export function createKimiWebClient(options = {}) {
             const controller = new AbortController();
             const timer = setTimeout(() => controller.abort(), KIMI_WEB_PATCH_TIMEOUT_MS);
             try {
-                const response = await fetchImpl(`${baseUrl}${KIMI_WEB_SESSION_PATH}/${encodeURIComponent(sessionId)}`, {
+                const response = await fetchImpl(joinUrl(baseUrl, `${KIMI_WEB_SESSION_PATH}/${encodeURIComponent(sessionId)}`), {
                     method: "PATCH",
                     headers: { "Content-Type": "application/json" },
                     body: JSON.stringify({ title: trimmed }),

--- a/runtime/kimi-web-client.ts
+++ b/runtime/kimi-web-client.ts
@@ -41,6 +41,16 @@ export function resolveKimiWebBaseUrl(env: NodeJS.ProcessEnv | undefined): strin
   return override.replace(/\/+$/, "");
 }
 
+// Join a base URL (e.g. `http://127.0.0.1:5494` or `http://127.0.0.1:5494/`)
+// with an absolute path (e.g. `/healthz`) without producing a double slash.
+// Uses the WHATWG URL parser so the result is always canonical. Note:
+// `new URL("/x", "http://host/sub/")` drops `/sub/`, which is correct here
+// because `baseUrl` is always an origin-only URL as produced by
+// `resolveKimiWebBaseUrl` — never a URL with a path suffix.
+function joinUrl(baseUrl: string, path: string): string {
+  return new URL(path, baseUrl).toString();
+}
+
 export function createKimiWebClient(options: KimiWebClientOptions = {}): KimiWebClient {
   const baseUrl = resolveKimiWebBaseUrl(options.env);
   const fetchImpl = options.fetchImpl ?? fetch;
@@ -51,7 +61,7 @@ export function createKimiWebClient(options: KimiWebClientOptions = {}): KimiWeb
       const controller = new AbortController();
       const timer = setTimeout(() => controller.abort(), KIMI_WEB_HEALTH_TIMEOUT_MS);
       try {
-        const response = await fetchImpl(`${baseUrl}${KIMI_WEB_HEALTH_PATH}`, {
+        const response = await fetchImpl(joinUrl(baseUrl, KIMI_WEB_HEALTH_PATH), {
           method: "GET",
           signal: controller.signal,
         });
@@ -79,7 +89,7 @@ export function createKimiWebClient(options: KimiWebClientOptions = {}): KimiWeb
       const timer = setTimeout(() => controller.abort(), KIMI_WEB_PATCH_TIMEOUT_MS);
       try {
         const response = await fetchImpl(
-          `${baseUrl}${KIMI_WEB_SESSION_PATH}/${encodeURIComponent(sessionId)}`,
+          joinUrl(baseUrl, `${KIMI_WEB_SESSION_PATH}/${encodeURIComponent(sessionId)}`),
           {
             method: "PATCH",
             headers: { "Content-Type": "application/json" },

--- a/tests/runtime/kimi-web-client.test.ts
+++ b/tests/runtime/kimi-web-client.test.ts
@@ -18,7 +18,23 @@ interface StubResponse {
   status: number;
 }
 
-function makeFetchStub(handler: (url: string, init: RequestInit) => StubResponse | Error) {
+interface FetchStubOptions {
+  // When set, the stub waits `delayMs` before resolving so the client's
+  // AbortController + setTimeout path can fire first and reject with an
+  // AbortError-shaped rejection (matching the runtime `fetch` contract).
+  delayMs?: number;
+}
+
+function makeAbortError(): Error {
+  const err = new Error("aborted");
+  err.name = "AbortError";
+  return err;
+}
+
+function makeFetchStub(
+  handler: (url: string, init: RequestInit) => StubResponse | Error,
+  options: FetchStubOptions = {},
+) {
   const calls: FetchRecord[] = [];
   const fn = async (input: string | URL | Request, init: RequestInit = {}) => {
     const url = input instanceof URL ? input.toString() : String(input);
@@ -27,6 +43,24 @@ function makeFetchStub(handler: (url: string, init: RequestInit) => StubResponse
       method: init.method ?? "GET",
       body: typeof init.body === "string" ? init.body : undefined,
     });
+    if (options.delayMs !== undefined) {
+      await new Promise<void>((resolve, reject) => {
+        const signal = init.signal as AbortSignal | null | undefined;
+        if (signal?.aborted) {
+          reject(makeAbortError());
+          return;
+        }
+        const timer = setTimeout(() => {
+          signal?.removeEventListener("abort", onAbort);
+          resolve();
+        }, options.delayMs);
+        const onAbort = () => {
+          clearTimeout(timer);
+          reject(makeAbortError());
+        };
+        signal?.addEventListener("abort", onAbort, { once: true });
+      });
+    }
     const result = handler(url, init);
     if (result instanceof Error) throw result;
     return {
@@ -72,6 +106,17 @@ describe("createKimiWebClient.healthCheck", () => {
     const { fetchImpl } = makeFetchStub(() => new Error("ECONNREFUSED"));
     const client = createKimiWebClient({ fetchImpl });
     expect(await client.healthCheck()).toBe(false);
+  });
+
+  test("normalizes trailing-slash base URLs without producing a double slash", async () => {
+    const { fetchImpl, calls } = makeFetchStub(() => ({ ok: true, status: 200 }));
+    const client = createKimiWebClient({
+      fetchImpl,
+      env: { KIMI_PLUGIN_CC_WEB_URL: "http://127.0.0.1:5494/" },
+    });
+    expect(await client.healthCheck()).toBe(true);
+    expect(calls[0].url).toBe("http://127.0.0.1:5494/healthz");
+    expect(calls[0].url).not.toContain("//healthz");
   });
 });
 
@@ -122,6 +167,42 @@ describe("createKimiWebClient.setSessionTitle", () => {
     const client = createKimiWebClient({ fetchImpl });
     const result = await client.setSessionTitle("abc", "title");
     expect(result).toMatchObject({ ok: false, reason: "unreachable" });
+  });
+
+  test("normalizes trailing-slash base URLs without producing a double slash", async () => {
+    const { fetchImpl, calls } = makeFetchStub(() => ({ ok: true, status: 200 }));
+    const client = createKimiWebClient({
+      fetchImpl,
+      env: { KIMI_PLUGIN_CC_WEB_URL: "http://127.0.0.1:5494/" },
+    });
+    const result = await client.setSessionTitle("abc-123", "title");
+    expect(result).toEqual({ ok: true, title: "title" });
+    expect(calls[0].url).toBe("http://127.0.0.1:5494/api/sessions/abc-123");
+    expect(calls[0].url).not.toContain("//api");
+  });
+});
+
+describe("createKimiWebClient AbortController timeouts", () => {
+  test("healthCheck returns false when the 200ms budget fires before fetch resolves", async () => {
+    const { fetchImpl } = makeFetchStub(() => ({ ok: true, status: 200 }), { delayMs: 5_000 });
+    const client = createKimiWebClient({ fetchImpl });
+    const start = Date.now();
+    const result = await client.healthCheck();
+    const elapsed = Date.now() - start;
+    expect(result).toBe(false);
+    // If the client's 200ms AbortController didn't fire, we'd wait the full 5s stub delay.
+    expect(elapsed).toBeLessThan(2_000);
+  });
+
+  test("setSessionTitle returns unreachable when the 2s budget fires before fetch resolves", async () => {
+    const { fetchImpl } = makeFetchStub(() => ({ ok: true, status: 200 }), { delayMs: 10_000 });
+    const client = createKimiWebClient({ fetchImpl });
+    const start = Date.now();
+    const result = await client.setSessionTitle("abc", "title");
+    const elapsed = Date.now() - start;
+    expect(result).toMatchObject({ ok: false, reason: "unreachable" });
+    // If the client's 2000ms AbortController didn't fire, we'd wait the full 10s stub delay.
+    expect(elapsed).toBeLessThan(5_000);
   });
 });
 


### PR DESCRIPTION
## Summary

Closes two low-severity items from the 0.1.5 audit tracked in `docs/followups.md`:

- **L3** — URL path concatenation. `runtime/kimi-web-client.ts` built request URLs with raw template literals (`${baseUrl}${KIMI_WEB_HEALTH_PATH}`), which produced a double slash whenever `baseUrl` had a trailing slash. Replaced with a small `joinUrl` helper that defers to the WHATWG URL parser (`new URL(path, baseUrl).toString()`) so the output is always canonical. A brief inline comment documents the subpath-dropping behavior — safe here because `resolveKimiWebBaseUrl` only ever produces origin-only URLs.
- **L2** — AbortController timeout test coverage. The `healthCheck` (200 ms) and `setSessionTitle` (2000 ms) timeouts previously had no test that actually exercised the abort path. Extended the test-only `makeFetchStub` with an optional `delayMs` that respects `init.signal` and rejects with an `AbortError`-shaped error when the client's own `AbortController` fires. Added two regression tests that set the stub delay well beyond each budget and assert the client aborts first.

## Changes

- `runtime/kimi-web-client.ts` — add `joinUrl` helper, swap both template-literal concatenations for it. No public API changes; timeout constants unchanged.
- `tests/runtime/kimi-web-client.test.ts` — new `FetchStubOptions { delayMs? }` parameter on `makeFetchStub` (backward-compatible default), new `makeAbortError` helper, 4 new tests:
  - `healthCheck > normalizes trailing-slash base URLs without producing a double slash`
  - `setSessionTitle > normalizes trailing-slash base URLs without producing a double slash`
  - `AbortController timeouts > healthCheck returns false when the 200ms budget fires before fetch resolves`
  - `AbortController timeouts > setSessionTitle returns unreachable when the 2s budget fires before fetch resolves`
- `dist/kimi-web-client.js` — rebuilt via `bun run build`, required for the drift gate.

## Test plan

- [x] `bun run check` — 113 pass (baseline 109 + 4 new), 0 fail, 1 skip (live Kimi integration), drift gate green
- [x] Existing 14 kimi-web-client tests unchanged and still passing
- [x] No changes outside `runtime/kimi-web-client.ts`, `tests/runtime/kimi-web-client.test.ts`, and the rebuilt `dist/kimi-web-client.js`

## Context

Part of the /batch Unit B dispatch. Plan file for orchestration context: `/Users/xulelin/.claude/plans/curried-seeking-barto.md`. Units A and C are running in parallel on independent file sets.