### PR TITLE
session-title: remove dead 200-char guard

### DIFF
--- a/dist/kimi-web-client.js
+++ b/dist/kimi-web-client.js
@@ -8,7 +8,6 @@
 // method for setting a session title. PATCH /api/sessions/{id} is the
 // documented HTTP API that powers the web UI's own rename flow, so we use it
 // directly. See 2026-04-15 investigation memo for the full protocol survey.
-import { KIMI_SESSION_TITLE_MAX_LENGTH } from "./session-title.js";
 export const DEFAULT_KIMI_WEB_BASE_URL = "http://127.0.0.1:5494";
 export const KIMI_WEB_HEALTH_PATH = "/healthz";
 export const KIMI_WEB_SESSION_PATH = "/api/sessions";
@@ -17,6 +16,10 @@ export const KIMI_WEB_SESSION_PATH = "/api/sessions";
 // 0.1.5 flagged 500ms as too generous when the server is reachable-but-slow.
 const KIMI_WEB_HEALTH_TIMEOUT_MS = 200;
 const KIMI_WEB_PATCH_TIMEOUT_MS = 2_000;
+// Defensive cap on arbitrary title input to the HTTP PATCH payload. Titles
+// produced by `buildSessionTitle` are naturally bounded to ~75 chars, but this
+// client accepts externally-supplied titles, so we keep a sanity ceiling.
+const KIMI_WEB_TITLE_MAX_LENGTH = 200;
 export function resolveKimiWebBaseUrl(env) {
     const override = env?.KIMI_PLUGIN_CC_WEB_URL?.trim();
     if (!override)
@@ -50,11 +53,11 @@ export function createKimiWebClient(options = {}) {
             if (!trimmed) {
                 return { ok: false, reason: "invalid-title", detail: "title is empty after trim" };
             }
-            if (trimmed.length > KIMI_SESSION_TITLE_MAX_LENGTH) {
+            if (trimmed.length > KIMI_WEB_TITLE_MAX_LENGTH) {
                 return {
                     ok: false,
                     reason: "invalid-title",
-                    detail: `title exceeds ${KIMI_SESSION_TITLE_MAX_LENGTH} chars`,
+                    detail: `title exceeds ${KIMI_WEB_TITLE_MAX_LENGTH} chars`,
                 };
             }
             const controller = new AbortController();

--- a/dist/session-title.js
+++ b/dist/session-title.js
@@ -10,7 +10,6 @@
 // scanning a session list than command name does.
 export const KIMI_SESSION_TITLE_PREFIX = "Kimi Task";
 export const KIMI_SESSION_TITLE_EXCERPT_LENGTH = 56;
-export const KIMI_SESSION_TITLE_MAX_LENGTH = 200;
 const WRITE_CAPABLE_COMMANDS = new Set(["rescue"]);
 // Prompts that begin with a label like "Task: ..." or "TODO: ..." produce
 // doubled titles such as "Kimi Task: Task: ..." when excerpted as-is. Strip
@@ -24,10 +23,7 @@ export function buildSessionTitle(commandType, prompt) {
     const excerpt = shortenForTitle(stripped, KIMI_SESSION_TITLE_EXCERPT_LENGTH);
     const base = excerpt ? `${KIMI_SESSION_TITLE_PREFIX}: ${excerpt}` : KIMI_SESSION_TITLE_PREFIX;
     const suffix = WRITE_CAPABLE_COMMANDS.has(commandType) ? " [write]" : "";
-    const full = `${base}${suffix}`;
-    return full.length <= KIMI_SESSION_TITLE_MAX_LENGTH
-        ? full
-        : `${full.slice(0, KIMI_SESSION_TITLE_MAX_LENGTH - 1)}…`;
+    return `${base}${suffix}`;
 }
 export function shortenForTitle(text, maxLength) {
     const normalized = text.replace(/\s+/g, " ").trim();

--- a/runtime/kimi-web-client.ts
+++ b/runtime/kimi-web-client.ts
@@ -9,8 +9,6 @@
 // documented HTTP API that powers the web UI's own rename flow, so we use it
 // directly. See 2026-04-15 investigation memo for the full protocol survey.
 
-import { KIMI_SESSION_TITLE_MAX_LENGTH } from "./session-title.js";
-
 export const DEFAULT_KIMI_WEB_BASE_URL = "http://127.0.0.1:5494";
 export const KIMI_WEB_HEALTH_PATH = "/healthz";
 export const KIMI_WEB_SESSION_PATH = "/api/sessions";
@@ -19,6 +17,10 @@ export const KIMI_WEB_SESSION_PATH = "/api/sessions";
 // 0.1.5 flagged 500ms as too generous when the server is reachable-but-slow.
 const KIMI_WEB_HEALTH_TIMEOUT_MS = 200;
 const KIMI_WEB_PATCH_TIMEOUT_MS = 2_000;
+// Defensive cap on arbitrary title input to the HTTP PATCH payload. Titles
+// produced by `buildSessionTitle` are naturally bounded to ~75 chars, but this
+// client accepts externally-supplied titles, so we keep a sanity ceiling.
+const KIMI_WEB_TITLE_MAX_LENGTH = 200;
 
 export interface KimiWebClientOptions {
   env?: NodeJS.ProcessEnv;
@@ -67,11 +69,11 @@ export function createKimiWebClient(options: KimiWebClientOptions = {}): KimiWeb
       if (!trimmed) {
         return { ok: false, reason: "invalid-title", detail: "title is empty after trim" };
       }
-      if (trimmed.length > KIMI_SESSION_TITLE_MAX_LENGTH) {
+      if (trimmed.length > KIMI_WEB_TITLE_MAX_LENGTH) {
         return {
           ok: false,
           reason: "invalid-title",
-          detail: `title exceeds ${KIMI_SESSION_TITLE_MAX_LENGTH} chars`,
+          detail: `title exceeds ${KIMI_WEB_TITLE_MAX_LENGTH} chars`,
         };
       }
 

--- a/runtime/session-title.ts
+++ b/runtime/session-title.ts
@@ -13,7 +13,6 @@ import type { ManagedCommandType } from "./types.js";
 
 export const KIMI_SESSION_TITLE_PREFIX = "Kimi Task";
 export const KIMI_SESSION_TITLE_EXCERPT_LENGTH = 56;
-export const KIMI_SESSION_TITLE_MAX_LENGTH = 200;
 
 const WRITE_CAPABLE_COMMANDS = new Set<ManagedCommandType>(["rescue"]);
 
@@ -30,10 +29,7 @@ export function buildSessionTitle(commandType: ManagedCommandType, prompt: strin
   const excerpt = shortenForTitle(stripped, KIMI_SESSION_TITLE_EXCERPT_LENGTH);
   const base = excerpt ? `${KIMI_SESSION_TITLE_PREFIX}: ${excerpt}` : KIMI_SESSION_TITLE_PREFIX;
   const suffix = WRITE_CAPABLE_COMMANDS.has(commandType) ? " [write]" : "";
-  const full = `${base}${suffix}`;
-  return full.length <= KIMI_SESSION_TITLE_MAX_LENGTH
-    ? full
-    : `${full.slice(0, KIMI_SESSION_TITLE_MAX_LENGTH - 1)}…`;
+  return `${base}${suffix}`;
 }
 
 export function shortenForTitle(text: string, maxLength: number): string {

--- a/tests/runtime/session-title.test.ts
+++ b/tests/runtime/session-title.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "bun:test";
 
 import {
-  KIMI_SESSION_TITLE_MAX_LENGTH,
+  KIMI_SESSION_TITLE_EXCERPT_LENGTH,
+  KIMI_SESSION_TITLE_PREFIX,
   buildSessionTitle,
   shortenForTitle,
   stripLeadingLabel,
@@ -57,10 +58,12 @@ describe("buildSessionTitle", () => {
     expect(title).toBe("Kimi Task: line one line two line three");
   });
 
-  test("final title never exceeds the 200-char API limit", () => {
+  test("final title is naturally bounded by excerpt length even for very long prompts", () => {
     const veryLongButNormalized = "x".repeat(500);
     const title = buildSessionTitle("rescue", veryLongButNormalized);
-    expect(title.length).toBeLessThanOrEqual(KIMI_SESSION_TITLE_MAX_LENGTH);
+    const naturalMax =
+      KIMI_SESSION_TITLE_PREFIX.length + ": ".length + KIMI_SESSION_TITLE_EXCERPT_LENGTH + " [write]".length;
+    expect(title.length).toBeLessThanOrEqual(naturalMax);
   });
 });
 


### PR DESCRIPTION
## Summary

Closes followups.md **L1**. Removes the unreachable 200-char clamp in `buildSessionTitle`.

The assembled title is `"Kimi Task: "` (11) + excerpt (<=56) + `" [write]"` (8) = **75 chars max**, so the `full.length <= KIMI_SESSION_TITLE_MAX_LENGTH` branch in `runtime/session-title.ts` was never taken. Deleted the constant, the conditional, and updated the one test that asserted against it to assert against the natural bound computed from `KIMI_SESSION_TITLE_PREFIX.length + ": ".length + KIMI_SESSION_TITLE_EXCERPT_LENGTH + " [write]".length`.

### Note on kimi-web-client.ts

The research brief said `KIMI_SESSION_TITLE_MAX_LENGTH` should have no users outside `session-title.ts` + its test, but `runtime/kimi-web-client.ts` was also importing it as a defensive cap on arbitrary title input to the `PATCH /api/sessions/{id}` payload. That's a semantically distinct concern from the dead clamp in `buildSessionTitle` (HTTP payload sanity ceiling vs an internal invariant that's already naturally enforced). Preserved that guard by inlining a local `KIMI_WEB_TITLE_MAX_LENGTH = 200` constant in `kimi-web-client.ts` with a comment explaining why it exists. No behavior change to the HTTP client.

### Context

Part of the 0.1.8 /batch parallel dispatch. Plan lives at `/Users/xulelin/.claude/plans/curried-seeking-barto.md`. Unit C of three independent units.

## Test plan

- [x] `bun run check` passes: 109 tests pass, 0 fail, 311 expect() calls, drift gate green
- [x] The 12 unrelated `session-title.test.ts` tests still pass unchanged
- [x] The updated regression test still uses `"x".repeat(500)` input and exercises the `rescue` path
- [x] No other files reference the deleted `KIMI_SESSION_TITLE_MAX_LENGTH`

Generated with [Claude Code](https://claude.com/claude-code)