### PR TITLE
rescue: close setup leak, spawn failure, artifact write, NODE_BIN validation

### DIFF
--- a/dist/commands/rescue.js
+++ b/dist/commands/rescue.js
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { spawn } from "node:child_process";
+import { access, constants as fsConstants } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { RuntimeError } from "../errors.js";
@@ -58,11 +59,18 @@ export async function runRescue(argv, context) {
             stream_log_path: logPath,
             error: null,
         });
-        await writeInvocationLogHeader(logPath, {
-            commandType: "rescue",
-            kimiSessionId: sessionResolution.sessionId,
-            cwd: context.cwd,
-        });
+        try {
+            await writeInvocationLogHeader(logPath, {
+                commandType: "rescue",
+                kimiSessionId: sessionResolution.sessionId,
+                cwd: context.cwd,
+            });
+        }
+        catch (error) {
+            const classified = new RuntimeError("RESCUE_LOG_HEADER_FAILED", `Failed to write rescue invocation log header: ${error.message ?? String(error)}`, "rescue.log-header", error instanceof Error ? { cause: error } : undefined);
+            await markJobFailed(store, paths, job, classified, "Rescue failed.", { phase: "failed" });
+            throw classified;
+        }
         if (parsed.background) {
             return startBackgroundRescue(job, prompt, context, paths, parsed.wait, {
                 reusedSession: sessionResolution.reusedSession,
@@ -92,32 +100,42 @@ export async function executeRescueJob(jobId, prompt, context, options) {
     let cancelling = false;
     let clientClosed = false;
     let cancelEscalationTimer;
-    const approvalPolicy = await createRescueApprovalPolicy(job.cwd);
-    const client = buildWireClient({
-        cwd: job.cwd,
-        env: context.env,
-        sessionId: job.kimi_session_id ?? randomUUID(),
-        agentFile: job.agent_profile,
-        model: job.model ?? undefined,
-        thinking: job.thinking ?? undefined,
-        logPath: job.stream_log_path,
-        approvalPolicy,
-    });
+    let client;
+    let signalsRegistered = false;
     const requestCancellation = () => {
-        if (cancelling) {
+        if (cancelling || !client) {
             return;
         }
         cancelling = true;
         client.beginCancellation();
         void client.cancel().catch(() => { });
         cancelEscalationTimer = setTimeout(() => {
-            client.terminateChild("SIGTERM");
+            client?.terminateChild("SIGTERM");
         }, 1_500);
         cancelEscalationTimer.unref();
     };
-    process.once("SIGTERM", requestCancellation);
-    process.once("SIGINT", requestCancellation);
     try {
+        let approvalPolicy;
+        try {
+            approvalPolicy = await createRescueApprovalPolicy(job.cwd);
+            client = buildWireClient({
+                cwd: job.cwd,
+                env: context.env,
+                sessionId: job.kimi_session_id ?? randomUUID(),
+                agentFile: job.agent_profile,
+                model: job.model ?? undefined,
+                thinking: job.thinking ?? undefined,
+                logPath: job.stream_log_path,
+                approvalPolicy,
+            });
+        }
+        catch (error) {
+            const classified = new RuntimeError("RESCUE_SETUP_FAILED", `Rescue setup failed: ${error.message ?? String(error)}`, "rescue.setup", error instanceof Error ? { cause: error } : undefined);
+            return await markJobFailed(store, paths, job, classified, "Rescue failed.", { phase: "failed" });
+        }
+        process.once("SIGTERM", requestCancellation);
+        process.once("SIGINT", requestCancellation);
+        signalsRegistered = true;
         if (options?.workerPid) {
             store.updateRunningJob(job.job_id, { pid: options.workerPid, phase: "worker-running" });
         }
@@ -147,7 +165,18 @@ export async function executeRescueJob(jobId, prompt, context, options) {
             });
         }
         const completedTurn = await client.prompt(prompt, "rescue");
-        const artifactPath = await writeArtifact(paths, job, renderRescueArtifact(completedTurn.finalText));
+        let artifactPath;
+        try {
+            if (context.env.KIMI_PLUGIN_CC_TEST_FAIL_WRITE_ARTIFACT === "1") {
+                throw new Error("Simulated artifact write failure (test seam).");
+            }
+            artifactPath = await writeArtifact(paths, job, renderRescueArtifact(completedTurn.finalText));
+        }
+        catch (writeError) {
+            process.stderr.write(`[kimi-plugin-cc] rescue artifact write failed for job ${job.job_id}; raw output follows:\n${completedTurn.finalText}\n`);
+            const classified = new RuntimeError("RESCUE_ARTIFACT_WRITE_FAILED", `Failed to write rescue artifact: ${writeError.message ?? String(writeError)}`, "rescue.artifact", writeError instanceof Error ? { cause: writeError } : undefined);
+            return await markJobFailed(store, paths, job, classified, "Rescue failed.", { phase: "failed" });
+        }
         return (store.markCompleted(job.job_id, {
             summary: firstMeaningfulLine(completedTurn.finalText),
             phase: "done",
@@ -163,12 +192,14 @@ export async function executeRescueJob(jobId, prompt, context, options) {
         return await markJobFailed(store, paths, job, classified, "Rescue failed.", { phase: "failed" });
     }
     finally {
-        process.removeListener("SIGTERM", requestCancellation);
-        process.removeListener("SIGINT", requestCancellation);
+        if (signalsRegistered) {
+            process.removeListener("SIGTERM", requestCancellation);
+            process.removeListener("SIGINT", requestCancellation);
+        }
         if (cancelEscalationTimer) {
             clearTimeout(cancelEscalationTimer);
         }
-        if (!clientClosed) {
+        if (client && !clientClosed) {
             await client.close().catch(() => { });
             clientClosed = true;
         }
@@ -222,6 +253,31 @@ function ensureSessionIsNotRunning(job) {
 }
 async function startBackgroundRescue(job, prompt, context, paths, wait, options) {
     const nodeBinary = context.env.KIMI_PLUGIN_CC_NODE_BIN || process.execPath;
+    // Only fast-path the `fs.access` check for absolute/relative paths. A bare
+    // name like "node" is resolved by spawn() via PATH; the spawn `error` listener
+    // will still surface ENOENT on nextTick for that path, classified as
+    // RESCUE_WORKER_SPAWN_FAILED via the listener below.
+    if (nodeBinary.includes("/") || nodeBinary.includes("\\")) {
+        try {
+            await access(nodeBinary, fsConstants.X_OK);
+        }
+        catch (accessError) {
+            const code = accessError.code;
+            if (code === "ENOENT" || code === "EACCES" || code === "EPERM") {
+                const classified = new RuntimeError("RESCUE_NODE_BIN_INVALID", `Configured Node binary is not executable: ${nodeBinary}. Set KIMI_PLUGIN_CC_NODE_BIN to a valid Node >=22.5 executable and retry.`, "rescue.worker.spawn", accessError instanceof Error ? { cause: accessError } : undefined);
+                const failStore = new JobStore(paths);
+                try {
+                    await markJobFailed(failStore, paths, job, classified, "Rescue failed.", { phase: "failed" });
+                }
+                finally {
+                    failStore.close();
+                }
+                throw classified;
+            }
+            // Any other errno (EIO, etc.) — fall through to the spawn attempt and let the
+            // existing spawn error path surface it.
+        }
+    }
     const spawnArgs = isCompiledRuntime
         ? [companionEntrypoint, "worker", "rescue", job.job_id]
         : ["--import", "tsx", companionEntrypoint, "worker", "rescue", job.job_id];
@@ -236,7 +292,43 @@ async function startBackgroundRescue(job, prompt, context, paths, wait, options)
         detached: true,
         stdio: "ignore",
     });
+    let spawnReportedFailure = false;
+    const spawnErrorPromise = new Promise((resolve) => {
+        let settled = false;
+        const settle = (value) => {
+            if (settled) {
+                return;
+            }
+            settled = true;
+            resolve(value);
+        };
+        child.once("error", (spawnError) => {
+            spawnReportedFailure = true;
+            settle(new RuntimeError("RESCUE_WORKER_SPAWN_FAILED", `Background rescue worker failed to spawn: ${spawnError.message}`, "rescue.worker.spawn", { cause: spawnError }));
+        });
+        // Give the event loop one tick to deliver a synchronous spawn error
+        // (ENOENT fires on process.nextTick). If nothing fires by then, the
+        // child is live and we can proceed.
+        setImmediate(() => settle(null));
+    });
+    child.on("close", (exitCode, signal) => {
+        if (spawnReportedFailure) {
+            return;
+        }
+        if (exitCode === null || exitCode === 0) {
+            return;
+        }
+        // The worker exited non-zero before any state update. If the job is
+        // still in its spawn phase, the worker never reached `executeRescueJob`.
+        const classified = new RuntimeError("RESCUE_WORKER_EXITED_EARLY", `Background rescue worker exited with code ${exitCode}${signal ? ` (signal ${signal})` : ""} before reporting a result.`, "rescue.worker.spawn");
+        void markEarlyExit(paths, job.job_id, classified);
+    });
     child.unref();
+    const spawnError = await spawnErrorPromise;
+    if (spawnError) {
+        await markSpawnFailure(paths, job.job_id, spawnError);
+        throw spawnError;
+    }
     const store = new JobStore(paths);
     try {
         store.updateRunningJob(job.job_id, {
@@ -258,6 +350,44 @@ async function startBackgroundRescue(job, prompt, context, paths, wait, options)
         job_id: job.job_id,
         command_type: job.command_type,
     }, null, 2)}\n`;
+}
+async function markSpawnFailure(paths, jobId, classified) {
+    const store = new JobStore(paths);
+    try {
+        const current = store.getJob(jobId);
+        if (!current || current.status !== "running") {
+            return;
+        }
+        await markJobFailed(store, paths, current, classified, "Rescue failed.", { phase: "failed" });
+    }
+    catch (writeError) {
+        process.stderr.write(`[kimi-plugin-cc] failed to mark rescue ${jobId} as spawn-failed: ${writeError.message ?? String(writeError)}\n`);
+    }
+    finally {
+        store.close();
+    }
+}
+async function markEarlyExit(paths, jobId, classified) {
+    const store = new JobStore(paths);
+    try {
+        const current = store.getJob(jobId);
+        if (!current || current.status !== "running") {
+            return;
+        }
+        // Only mark failure if the worker exited before advancing past the spawn phase.
+        // Once the worker reaches worker-running or turn-running, the child owns the
+        // job state and the parent's close listener must not race with it.
+        if (current.phase !== "worker-spawned" && current.phase !== "queued") {
+            return;
+        }
+        await markJobFailed(store, paths, current, classified, "Rescue failed.", { phase: "failed" });
+    }
+    catch (writeError) {
+        process.stderr.write(`[kimi-plugin-cc] failed to mark rescue ${jobId} as early-exit: ${writeError.message ?? String(writeError)}\n`);
+    }
+    finally {
+        store.close();
+    }
 }
 function shorten(text, max) {
     const normalized = text.replace(/\s+/g, " ").trim();

--- a/runtime/commands/rescue.ts
+++ b/runtime/commands/rescue.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { spawn } from "node:child_process";
+import { access, constants as fsConstants } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -69,11 +70,22 @@ export async function runRescue(argv: string[], context: CommandContext): Promis
       error: null,
     });
 
-    await writeInvocationLogHeader(logPath, {
-      commandType: "rescue",
-      kimiSessionId: sessionResolution.sessionId,
-      cwd: context.cwd,
-    });
+    try {
+      await writeInvocationLogHeader(logPath, {
+        commandType: "rescue",
+        kimiSessionId: sessionResolution.sessionId,
+        cwd: context.cwd,
+      });
+    } catch (error) {
+      const classified = new RuntimeError(
+        "RESCUE_LOG_HEADER_FAILED",
+        `Failed to write rescue invocation log header: ${(error as Error).message ?? String(error)}`,
+        "rescue.log-header",
+        error instanceof Error ? { cause: error } : undefined,
+      );
+      await markJobFailed(store, paths, job, classified, "Rescue failed.", { phase: "failed" });
+      throw classified;
+    }
 
     if (parsed.background) {
       return startBackgroundRescue(job, prompt, context, paths, parsed.wait, {
@@ -112,20 +124,10 @@ export async function executeRescueJob(
   let cancelling = false;
   let clientClosed = false;
   let cancelEscalationTimer: ReturnType<typeof setTimeout> | undefined;
-  const approvalPolicy = await createRescueApprovalPolicy(job.cwd);
-  const client = buildWireClient({
-    cwd: job.cwd,
-    env: context.env,
-    sessionId: job.kimi_session_id ?? randomUUID(),
-    agentFile: job.agent_profile,
-    model: job.model ?? undefined,
-    thinking: job.thinking ?? undefined,
-    logPath: job.stream_log_path,
-    approvalPolicy,
-  });
-
+  let client: ReturnType<typeof buildWireClient> | undefined;
+  let signalsRegistered = false;
   const requestCancellation = () => {
-    if (cancelling) {
+    if (cancelling || !client) {
       return;
     }
 
@@ -133,15 +135,39 @@ export async function executeRescueJob(
     client.beginCancellation();
     void client.cancel().catch(() => {});
     cancelEscalationTimer = setTimeout(() => {
-      client.terminateChild("SIGTERM");
+      client?.terminateChild("SIGTERM");
     }, 1_500);
     cancelEscalationTimer.unref();
   };
 
-  process.once("SIGTERM", requestCancellation);
-  process.once("SIGINT", requestCancellation);
-
   try {
+    let approvalPolicy;
+    try {
+      approvalPolicy = await createRescueApprovalPolicy(job.cwd);
+      client = buildWireClient({
+        cwd: job.cwd,
+        env: context.env,
+        sessionId: job.kimi_session_id ?? randomUUID(),
+        agentFile: job.agent_profile,
+        model: job.model ?? undefined,
+        thinking: job.thinking ?? undefined,
+        logPath: job.stream_log_path,
+        approvalPolicy,
+      });
+    } catch (error) {
+      const classified = new RuntimeError(
+        "RESCUE_SETUP_FAILED",
+        `Rescue setup failed: ${(error as Error).message ?? String(error)}`,
+        "rescue.setup",
+        error instanceof Error ? { cause: error } : undefined,
+      );
+      return await markJobFailed(store, paths, job, classified, "Rescue failed.", { phase: "failed" });
+    }
+
+    process.once("SIGTERM", requestCancellation);
+    process.once("SIGINT", requestCancellation);
+    signalsRegistered = true;
+
     if (options?.workerPid) {
       store.updateRunningJob(job.job_id, { pid: options.workerPid, phase: "worker-running" });
     }
@@ -179,7 +205,25 @@ export async function executeRescueJob(
     }
 
     const completedTurn = await client.prompt(prompt, "rescue");
-    const artifactPath = await writeArtifact(paths, job, renderRescueArtifact(completedTurn.finalText));
+    let artifactPath: string;
+    try {
+      if (context.env.KIMI_PLUGIN_CC_TEST_FAIL_WRITE_ARTIFACT === "1") {
+        throw new Error("Simulated artifact write failure (test seam).");
+      }
+      artifactPath = await writeArtifact(paths, job, renderRescueArtifact(completedTurn.finalText));
+    } catch (writeError) {
+      process.stderr.write(
+        `[kimi-plugin-cc] rescue artifact write failed for job ${job.job_id}; raw output follows:\n${completedTurn.finalText}\n`,
+      );
+      const classified = new RuntimeError(
+        "RESCUE_ARTIFACT_WRITE_FAILED",
+        `Failed to write rescue artifact: ${(writeError as Error).message ?? String(writeError)}`,
+        "rescue.artifact",
+        writeError instanceof Error ? { cause: writeError } : undefined,
+      );
+      return await markJobFailed(store, paths, job, classified, "Rescue failed.", { phase: "failed" });
+    }
+
     return (
       store.markCompleted(job.job_id, {
         summary: firstMeaningfulLine(completedTurn.finalText),
@@ -203,13 +247,15 @@ export async function executeRescueJob(
     const classified = classifyManagedCommandFailure(error, "rescue", job.job_id);
     return await markJobFailed(store, paths, job, classified, "Rescue failed.", { phase: "failed" });
   } finally {
-    process.removeListener("SIGTERM", requestCancellation);
-    process.removeListener("SIGINT", requestCancellation);
+    if (signalsRegistered) {
+      process.removeListener("SIGTERM", requestCancellation);
+      process.removeListener("SIGINT", requestCancellation);
+    }
     if (cancelEscalationTimer) {
       clearTimeout(cancelEscalationTimer);
     }
 
-    if (!clientClosed) {
+    if (client && !clientClosed) {
       await client.close().catch(() => {});
       clientClosed = true;
     }
@@ -300,6 +346,36 @@ async function startBackgroundRescue(
   options?: { reusedSession?: boolean },
 ): Promise<string> {
   const nodeBinary = context.env.KIMI_PLUGIN_CC_NODE_BIN || process.execPath;
+
+  // Only fast-path the `fs.access` check for absolute/relative paths. A bare
+  // name like "node" is resolved by spawn() via PATH; the spawn `error` listener
+  // will still surface ENOENT on nextTick for that path, classified as
+  // RESCUE_WORKER_SPAWN_FAILED via the listener below.
+  if (nodeBinary.includes("/") || nodeBinary.includes("\\")) {
+    try {
+      await access(nodeBinary, fsConstants.X_OK);
+    } catch (accessError) {
+      const code = (accessError as NodeJS.ErrnoException).code;
+      if (code === "ENOENT" || code === "EACCES" || code === "EPERM") {
+        const classified = new RuntimeError(
+          "RESCUE_NODE_BIN_INVALID",
+          `Configured Node binary is not executable: ${nodeBinary}. Set KIMI_PLUGIN_CC_NODE_BIN to a valid Node >=22.5 executable and retry.`,
+          "rescue.worker.spawn",
+          accessError instanceof Error ? { cause: accessError } : undefined,
+        );
+        const failStore = new JobStore(paths);
+        try {
+          await markJobFailed(failStore, paths, job, classified, "Rescue failed.", { phase: "failed" });
+        } finally {
+          failStore.close();
+        }
+        throw classified;
+      }
+      // Any other errno (EIO, etc.) — fall through to the spawn attempt and let the
+      // existing spawn error path surface it.
+    }
+  }
+
   const spawnArgs = isCompiledRuntime
     ? [companionEntrypoint, "worker", "rescue", job.job_id]
     : ["--import", "tsx", companionEntrypoint, "worker", "rescue", job.job_id];
@@ -314,7 +390,57 @@ async function startBackgroundRescue(
     detached: true,
     stdio: "ignore",
   });
+
+  let spawnReportedFailure = false;
+  const spawnErrorPromise = new Promise<RuntimeError | null>((resolve) => {
+    let settled = false;
+    const settle = (value: RuntimeError | null) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolve(value);
+    };
+    child.once("error", (spawnError) => {
+      spawnReportedFailure = true;
+      settle(
+        new RuntimeError(
+          "RESCUE_WORKER_SPAWN_FAILED",
+          `Background rescue worker failed to spawn: ${spawnError.message}`,
+          "rescue.worker.spawn",
+          { cause: spawnError },
+        ),
+      );
+    });
+    // Give the event loop one tick to deliver a synchronous spawn error
+    // (ENOENT fires on process.nextTick). If nothing fires by then, the
+    // child is live and we can proceed.
+    setImmediate(() => settle(null));
+  });
+
+  child.on("close", (exitCode, signal) => {
+    if (spawnReportedFailure) {
+      return;
+    }
+    if (exitCode === null || exitCode === 0) {
+      return;
+    }
+    // The worker exited non-zero before any state update. If the job is
+    // still in its spawn phase, the worker never reached `executeRescueJob`.
+    const classified = new RuntimeError(
+      "RESCUE_WORKER_EXITED_EARLY",
+      `Background rescue worker exited with code ${exitCode}${signal ? ` (signal ${signal})` : ""} before reporting a result.`,
+      "rescue.worker.spawn",
+    );
+    void markEarlyExit(paths, job.job_id, classified);
+  });
   child.unref();
+
+  const spawnError = await spawnErrorPromise;
+  if (spawnError) {
+    await markSpawnFailure(paths, job.job_id, spawnError);
+    throw spawnError;
+  }
 
   const store = new JobStore(paths);
   try {
@@ -347,6 +473,54 @@ async function startBackgroundRescue(
     null,
     2,
   )}\n`;
+}
+
+async function markSpawnFailure(
+  paths: PluginPaths,
+  jobId: string,
+  classified: RuntimeError,
+): Promise<void> {
+  const store = new JobStore(paths);
+  try {
+    const current = store.getJob(jobId);
+    if (!current || current.status !== "running") {
+      return;
+    }
+    await markJobFailed(store, paths, current, classified, "Rescue failed.", { phase: "failed" });
+  } catch (writeError) {
+    process.stderr.write(
+      `[kimi-plugin-cc] failed to mark rescue ${jobId} as spawn-failed: ${(writeError as Error).message ?? String(writeError)}\n`,
+    );
+  } finally {
+    store.close();
+  }
+}
+
+async function markEarlyExit(
+  paths: PluginPaths,
+  jobId: string,
+  classified: RuntimeError,
+): Promise<void> {
+  const store = new JobStore(paths);
+  try {
+    const current = store.getJob(jobId);
+    if (!current || current.status !== "running") {
+      return;
+    }
+    // Only mark failure if the worker exited before advancing past the spawn phase.
+    // Once the worker reaches worker-running or turn-running, the child owns the
+    // job state and the parent's close listener must not race with it.
+    if (current.phase !== "worker-spawned" && current.phase !== "queued") {
+      return;
+    }
+    await markJobFailed(store, paths, current, classified, "Rescue failed.", { phase: "failed" });
+  } catch (writeError) {
+    process.stderr.write(
+      `[kimi-plugin-cc] failed to mark rescue ${jobId} as early-exit: ${(writeError as Error).message ?? String(writeError)}\n`,
+    );
+  } finally {
+    store.close();
+  }
 }
 
 function shorten(text: string, max: number): string {

--- a/tests/runtime/rescue-command.test.ts
+++ b/tests/runtime/rescue-command.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { randomUUID } from "node:crypto";
 import { mkdir, readFile, symlink } from "node:fs/promises";
 import path from "node:path";
 
@@ -407,6 +408,140 @@ describe("rescue command lifecycle", () => {
       }
 
       expect(alive).toBe(false);
+    } finally {
+      await cleanupTestPath(pluginDataRoot);
+      await cleanupTestPath(repoRoot);
+    }
+  });
+
+  test("rescue setup failure marks the job failed, releases signal listeners, and closes the job store", async () => {
+    const pluginDataRoot = await createTestPluginDataRoot("rescue-setup-leak");
+    const invocationPath = path.join(pluginDataRoot, "rescue-setup-leak.jsonl");
+    const env = makeMockEnv(pluginDataRoot, "rescue-success", invocationPath);
+    // A cwd that cannot be realpath'd forces createRescueApprovalPolicy to
+    // throw ENOENT before the Wire client is built.
+    const missingCwd = path.join(pluginDataRoot, "definitely", "missing", randomUUID());
+
+    const sigTermBefore = process.listenerCount("SIGTERM");
+    const sigIntBefore = process.listenerCount("SIGINT");
+
+    try {
+      // Pre-create a git-repo fixture just to satisfy the initial repo-identity probe;
+      // then redirect the CommandContext at the missing path for the actual execution.
+      const realRepo = await createGitRepoFixture("rescue-setup-leak-repo");
+      try {
+        // Seed a rescue job whose cwd cannot be realpath'd — this forces
+        // createRescueApprovalPolicy to throw ENOENT inside the new setup
+        // try/catch before any Wire client or signal listeners are attached.
+        const seedContext = makeContext(realRepo, env);
+        await ensurePluginPaths(resolvePluginPaths(env));
+        const store = new JobStore(resolvePluginPaths(env));
+        let createdJob;
+        try {
+          createdJob = store.createJob({
+            job_id: randomUUID(),
+            repo_id: "setup-leak-repo",
+            command_type: "rescue",
+            cwd: missingCwd,
+            model: null,
+            thinking: null,
+            background: false,
+            pid: null,
+            kimi_pid: null,
+            status: "running",
+            kimi_session_id: randomUUID(),
+            agent_profile: "runtime/agents/rescue.yaml",
+            prompt_digest: "deadbeef",
+            summary: "setup leak test",
+            phase: "starting",
+            final_output_path: null,
+            stream_log_path: path.join(pluginDataRoot, "logs", `rescue-setup-leak-${randomUUID()}.jsonl`),
+            error: null,
+          });
+        } finally {
+          store.close();
+        }
+
+        const { executeRescueJob } = await import("../../runtime/commands/rescue.js");
+        const result = await executeRescueJob(createdJob.job_id, "dummy prompt", seedContext);
+
+        expect(result.status).toBe("failed");
+        expect(result.phase).toBe("failed");
+        expect(result.error?.stage).toBe("rescue.setup");
+        expect(result.error?.code).toBe("RESCUE_SETUP_FAILED");
+
+        // No orphaned signal listeners should remain — setup failure runs
+        // before process.once registration.
+        expect(process.listenerCount("SIGTERM")).toBe(sigTermBefore);
+        expect(process.listenerCount("SIGINT")).toBe(sigIntBefore);
+
+        // Fresh JobStore reopen must succeed (the failure path closed the
+        // previous store — no busy lock should be held).
+        const reopen = new JobStore(resolvePluginPaths(env));
+        try {
+          const persisted = reopen.getJob(createdJob.job_id);
+          expect(persisted?.status).toBe("failed");
+          expect(persisted?.phase).toBe("failed");
+        } finally {
+          reopen.close();
+        }
+      } finally {
+        await cleanupTestPath(realRepo);
+      }
+    } finally {
+      await cleanupTestPath(pluginDataRoot);
+    }
+  });
+
+  test("rescue fails fast when KIMI_PLUGIN_CC_NODE_BIN points at a missing binary", async () => {
+    const pluginDataRoot = await createTestPluginDataRoot("rescue-node-bin-invalid");
+    const repoRoot = await createGitRepoFixture("rescue-node-bin-invalid-repo");
+    const invocationPath = path.join(pluginDataRoot, "rescue-node-bin-invalid.jsonl");
+    const env = makeMockEnv(pluginDataRoot, "rescue-success", invocationPath);
+    env.KIMI_PLUGIN_CC_NODE_BIN = `/tmp/kimi-plugin-cc-missing-node-${randomUUID()}`;
+
+    try {
+      await expect(
+        runRescue(["--background", "Do", "the", "work"], makeContext(repoRoot, env)),
+      ).rejects.toMatchObject({
+        code: "RESCUE_NODE_BIN_INVALID",
+      });
+
+      const status = JSON.parse(await runStatus(["--type", "rescue"], makeContext(repoRoot, env))) as {
+        status: string;
+        phase: string | null;
+        error: { code?: string; stage?: string } | null;
+      };
+      expect(status.status).toBe("failed");
+      expect(status.phase).toBe("failed");
+      expect(status.error?.code).toBe("RESCUE_NODE_BIN_INVALID");
+      expect(status.error?.stage).toBe("rescue.worker.spawn");
+    } finally {
+      await cleanupTestPath(pluginDataRoot);
+      await cleanupTestPath(repoRoot);
+    }
+  });
+
+  test("rescue classifies writeArtifact failure as RESCUE_ARTIFACT_WRITE_FAILED", async () => {
+    const pluginDataRoot = await createTestPluginDataRoot("rescue-artifact-write-fail");
+    const repoRoot = await createGitRepoFixture("rescue-artifact-write-fail-repo");
+    const invocationPath = path.join(pluginDataRoot, "rescue-artifact-write-fail.jsonl");
+    const env = makeMockEnv(pluginDataRoot, "rescue-success", invocationPath);
+    env.KIMI_PLUGIN_CC_TEST_FAIL_WRITE_ARTIFACT = "1";
+
+    try {
+      const output = await runRescue(["Implement", "the", "fix"], makeContext(repoRoot, env));
+      const status = JSON.parse(await runStatus(["--type", "rescue"], makeContext(repoRoot, env))) as {
+        status: string;
+        phase: string | null;
+        error: { code?: string; stage?: string } | null;
+      };
+
+      expect(output).toContain("# Failed Job");
+      expect(status.status).toBe("failed");
+      expect(status.phase).toBe("failed");
+      expect(status.error?.code).toBe("RESCUE_ARTIFACT_WRITE_FAILED");
+      expect(status.error?.stage).toBe("rescue.artifact");
     } finally {
       await cleanupTestPath(pluginDataRoot);
       await cleanupTestPath(repoRoot);


### PR DESCRIPTION
## Summary

Hardens four error paths in `/kimi:rescue` from `docs/followups.md` rescue section. This is **Unit A** of a parallel /batch dispatch; Units B and C touch other files and are non-conflicting.

### Followups items closed

- **Item 1 — pre-try setup leak**. `executeRescueJob` now runs `createRescueApprovalPolicy` and `buildWireClient` inside the main `try` via a nested setup `try/catch`. On failure the job is marked failed with stage `rescue.setup` / phase `failed`, `JobStore` closes via the outer `finally`, and `SIGTERM`/`SIGINT` listeners are only registered after setup succeeds (guarded by `signalsRegistered`). The `client.close()` cleanup is guarded on `client` being defined.
- **Item 2 — background worker spawn failure surfacing**. `startBackgroundRescue` attaches `error` and `close` listeners to the spawned child. Spawn errors resolve a bounded `Promise` (drained before `runRescue` returns) and are classified as `RESCUE_WORKER_SPAWN_FAILED`. Non-zero `close` events while the job is still in `worker-spawned`/`queued` phase are classified as `RESCUE_WORKER_EXITED_EARLY`, eliminating the phantom-running-job path that previously only resolved via `JOB_WAIT_TIMEOUT`.
- **Item 6 — writeArtifact / writeInvocationLogHeader classification**. `writeArtifact` is wrapped in its own `try/catch` and classified as `RESCUE_ARTIFACT_WRITE_FAILED` (stage `rescue.artifact`); raw Kimi output is best-effort dumped to stderr so it isn't silently lost. `writeInvocationLogHeader` in `runRescue` is similarly guarded as `RESCUE_LOG_HEADER_FAILED` (stage `rescue.log-header`).
- **Item 7 — NODE_BIN fast-path validation**. `startBackgroundRescue` now `fs.access`-checks `nodeBinary` with `X_OK` before `spawn()` when the value contains a path separator. On `ENOENT`/`EACCES`/`EPERM` it throws `RESCUE_NODE_BIN_INVALID` with an actionable message. Bare names like `"node"` fall through to `spawn()`'s PATH resolution, where the new `error` listener catches residual failures.

### Invariants preserved

- Pass-through output contract — no JSON, no new `rescue-system.md` content, no agent-profile changes.
- Summary field still has exactly two writes (creation at `runRescue` line ~66, completion at `executeRescueJob` line ~230).
- Every new `markJobFailed`/`markJobCancelled` call site threads `{ phase: "failed" }` or `{ phase: "cancelled" }` per the f1577c4 terminal-phase contract.
- Approval allowlist untouched.

### New tests (3)

- **rescue setup failure** — seeds a job with an un-`realpath`able `cwd`, calls `executeRescueJob` directly, and asserts the job lands `failed` with stage `rescue.setup` + phase `failed`, that `process.listenerCount("SIGTERM")` and `SIGINT` are unchanged, and that the `JobStore` can be reopened without a busy lock.
- **rescue NODE_BIN invalid** — sets `KIMI_PLUGIN_CC_NODE_BIN` to `/tmp/kimi-plugin-cc-missing-node-<uuid>`, runs `runRescue --background`, and asserts it rejects with `RESCUE_NODE_BIN_INVALID` in bounded time (no `JOB_WAIT_TIMEOUT`).
- **rescue artifact write failure** — sets `KIMI_PLUGIN_CC_TEST_FAIL_WRITE_ARTIFACT=1` (internal test seam in the new try/catch) and asserts the job lands `failed` with stage `rescue.artifact` + code `RESCUE_ARTIFACT_WRITE_FAILED`. The external disk-full approach was too fragile given `ensurePluginPaths`' auto-mkdir, so the env-var seam (explicitly permitted by the plan) was used.

### Test results

- Baseline: 109 pass / 311 expect calls (18 files)
- After: **112 pass / 329 expect calls** / 0 fail / 1 skip (18 files)
- `bun run check` green end-to-end (tsc + tests + `git diff --exit-code -- dist` drift gate)

## Test plan

- [x] `bun run check` green on branch HEAD
- [x] New tests exercise the three new failure classifications
- [x] Existing 11 rescue tests still pass (cancellation, resume, allowlist, background, empty-output fallback)
- [x] `dist/commands/rescue.js` rebuilt and staged in the same commit
- [ ] Follow-up: live `scripts/smoke-rescue-drift.sh` run by operator (out of scope for /batch)

Context: plan file at `/Users/xulelin/.claude/plans/curried-seeking-barto.md`.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>